### PR TITLE
Platform security audit + critical remediations

### DIFF
--- a/__tests__/lib/auth-privilege-model.test.ts
+++ b/__tests__/lib/auth-privilege-model.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Regression coverage for audit remediations around owner allowlist.
+ * Isolates isOwnerAdminUser without loading Next/Supabase auth helpers.
+ */
+
+describe('platform admin privilege model (audit)', () => {
+  const prevIds = process.env.OWNER_USER_IDS
+  const prevEmails = process.env.OWNER_ADMIN_EMAILS
+
+  function parseAllowlist(raw?: string) {
+    return (raw || '')
+      .split(',')
+      .map((item) => item.trim().toLowerCase())
+      .filter(Boolean)
+  }
+
+  function isOwnerAdminUser(user: any) {
+    const ownerIds = parseAllowlist(process.env.OWNER_USER_IDS)
+    const ownerEmails = parseAllowlist(process.env.OWNER_ADMIN_EMAILS)
+    const userId = String(user?.id || '').toLowerCase()
+    const userEmail = String(user?.email || '').toLowerCase()
+    return (!!userId && ownerIds.includes(userId)) || (!!userEmail && ownerEmails.includes(userEmail))
+  }
+
+  afterEach(() => {
+    process.env.OWNER_USER_IDS = prevIds
+    process.env.OWNER_ADMIN_EMAILS = prevEmails
+  })
+
+  it('matches allowlisted id and email only', () => {
+    process.env.OWNER_USER_IDS = 'aaa-bbb-ccc'
+    process.env.OWNER_ADMIN_EMAILS = 'owner@example.com'
+
+    expect(isOwnerAdminUser({ id: 'aaa-bbb-ccc', email: 'other@example.com' })).toBe(true)
+    expect(isOwnerAdminUser({ id: 'other', email: 'owner@example.com' })).toBe(true)
+    expect(isOwnerAdminUser({ id: 'other', email: 'user@example.com' })).toBe(false)
+    expect(isOwnerAdminUser(null)).toBe(false)
+  })
+
+  it('does not treat profiles.role-style fields as owner evidence', () => {
+    process.env.OWNER_USER_IDS = ''
+    process.env.OWNER_ADMIN_EMAILS = ''
+    expect(isOwnerAdminUser({ id: 'anyone', email: 'admin@example.com', role: 'admin' })).toBe(false)
+  })
+})

--- a/app/api/admin/auth/preflight/route.ts
+++ b/app/api/admin/auth/preflight/route.ts
@@ -5,38 +5,32 @@ export const dynamic = "force-dynamic";
 
 /**
  * Non-secret ops check for admin login (safe to call from browser).
- * Use after setting Vercel env vars + redeploy.
+ * Intentionally minimal — avoids leaking project refs, admin counts, or
+ * individual secret-presence flags to unauthenticated callers.
  */
 export async function GET(): Promise<NextResponse> {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim() ?? "";
-  const projectRef = url.match(/https:\/\/([^.]+)\.supabase\.co/)?.[1] ?? null;
+  const serviceRoleConfigured = Boolean(process.env.SUPABASE_SERVICE_ROLE_KEY?.trim());
+  const adminPasswordConfigured = Boolean(process.env.PLATFORM_ADMIN_PASSWORD?.trim());
+  const supabaseUrlConfigured = Boolean(url);
 
-  let activeAdminCount: number | null = null;
-  let rosterError: string | null = null;
-
+  let rosterReady = false;
   if (supabaseAdmin) {
     const { count, error } = await supabaseAdmin
       .from("platform_admins")
       .select("id", { count: "exact", head: true })
       .eq("is_active", true);
-
-    if (error) {
-      rosterError = error.message;
-    } else {
-      activeAdminCount = count ?? 0;
-    }
+    rosterReady = !error && (count ?? 0) > 0;
   }
+
+  const ready =
+    serviceRoleConfigured &&
+    adminPasswordConfigured &&
+    supabaseUrlConfigured &&
+    rosterReady;
 
   return NextResponse.json({
     ok: true,
-    serviceRoleConfigured: Boolean(process.env.SUPABASE_SERVICE_ROLE_KEY?.trim()),
-    adminPasswordConfigured: Boolean(process.env.PLATFORM_ADMIN_PASSWORD?.trim()),
-    supabaseUrlConfigured: Boolean(url),
-    supabaseProjectRef: projectRef,
-    twilioAdminMode: process.env.PLATFORM_ADMIN_USE_TWILIO === "true",
-    activePlatformAdmins: activeAdminCount,
-    rosterError,
-    expectedProjectRef: "yxzypekwyuopbanroobr",
-    projectRefMatches: projectRef === "yxzypekwyuopbanroobr",
+    ready,
   });
 }

--- a/app/api/donations/share/route.ts
+++ b/app/api/donations/share/route.ts
@@ -1,11 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
 import { normalizePhoneE164 } from "@/lib/phone";
 import { sendSms } from "@/lib/twilio-sms";
+import { rateLimit, getClientKeyFromHeaders } from "@/lib/rate-limit";
+import { supabaseAdmin } from "@/lib/supabase";
 
 export const dynamic = "force-dynamic";
 
+/** Max custom message length to limit SMS cost / abuse. */
+const MAX_MESSAGE_LEN = 160;
+
 export async function POST(req: NextRequest): Promise<NextResponse> {
   try {
+    const key = getClientKeyFromHeaders(req.headers);
+    if (!rateLimit(`donations-share:${key}`, 5)) {
+      return NextResponse.json({ ok: false, error: "Too many requests" }, { status: 429 });
+    }
+
     const body = await req.json();
     const { phone, eventId, message } = body || {};
     if (!phone || !eventId) {
@@ -17,9 +27,26 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       return NextResponse.json({ ok: false, error: "Invalid phone number" }, { status: 400 });
     }
 
+    // Verify event exists and is published before sending SMS (cost control).
+    if (!supabaseAdmin) {
+      return NextResponse.json({ ok: false, error: "Service unavailable" }, { status: 503 });
+    }
+    const { data: event, error: eventError } = await supabaseAdmin
+      .from("events")
+      .select("id, is_published")
+      .eq("id", String(eventId))
+      .maybeSingle();
+
+    if (eventError || !event || event.is_published === false) {
+      return NextResponse.json({ ok: false, error: "Event not found" }, { status: 404 });
+    }
+
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
     const eventUrl = `${appUrl}/events/${encodeURIComponent(String(eventId))}`;
-    const prefix = typeof message === "string" && message.trim() ? `${message.trim()}\n\n` : "";
+    // Strip control chars; cap length — custom text is optional branding only.
+    const rawMessage = typeof message === "string" ? message.replace(/[\r\n\t]+/g, " ").trim() : "";
+    const safeMessage = rawMessage.slice(0, MAX_MESSAGE_LEN);
+    const prefix = safeMessage ? `${safeMessage}\n\n` : "";
     const text = `${prefix}Support this event on EventraiseHub: ${eventUrl}`;
 
     const sent = await sendSms(e164, text);

--- a/app/api/events/[id]/payouts/route.ts
+++ b/app/api/events/[id]/payouts/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
 import { requireEventAccess } from '@/lib/auth-utils'
+import { resolvePlatformAdminAccess } from '@/lib/platform-admin'
+
+/** Statuses organizers may set. Settlement completion is platform-admin only. */
+const ORGANIZER_ALLOWED_STATUSES = new Set(['requested'])
+const PLATFORM_COMPLETION_STATUSES = new Set(['processing', 'completed', 'failed', 'cancelled'])
 
 export async function GET(req: NextRequest, { params }: any) {
   try {
@@ -8,7 +13,7 @@ export async function GET(req: NextRequest, { params }: any) {
     if (!id) return NextResponse.json({ error: 'Missing id' }, { status: 400 })
 
     // Use standardized authentication
-    const { user, db, event } = await requireEventAccess(req, id)
+    const { event } = await requireEventAccess(req, id)
 
     if (!supabaseAdmin) return NextResponse.json({ error: 'Database unavailable' }, { status: 500 })
 
@@ -88,12 +93,13 @@ export async function POST(req: NextRequest, { params }: any) {
     if (!id) return NextResponse.json({ error: 'Missing id' }, { status: 400 })
 
     // Use standardized authentication
-    const { user, db, event } = await requireEventAccess(req, id)
+    const { user } = await requireEventAccess(req, id)
 
     if (!supabaseAdmin) return NextResponse.json({ error: 'Database unavailable' }, { status: 500 })
 
     const body = await req.json().catch(() => ({}))
     const { action } = body
+    const platform = await resolvePlatformAdminAccess(user)
 
     if (action === 'create_payout') {
       // Create a new payout for this event
@@ -119,11 +125,27 @@ export async function POST(req: NextRequest, { params }: any) {
         return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
       }
 
-      const updateData: any = { payout_status: status }
+      const nextStatus = String(status)
+
+      // Organizers may only request cashout; platform admins settle.
+      if (PLATFORM_COMPLETION_STATUSES.has(nextStatus) && !platform.isPlatformAdmin) {
+        return NextResponse.json(
+          { error: 'Only platform admins can mark payouts processing/completed/failed' },
+          { status: 403 },
+        )
+      }
+      if (!platform.isPlatformAdmin && !ORGANIZER_ALLOWED_STATUSES.has(nextStatus)) {
+        return NextResponse.json(
+          { error: 'Organizers may only set payout status to requested' },
+          { status: 403 },
+        )
+      }
+
+      const updateData: any = { payout_status: nextStatus }
       if (method) updateData.payout_method = method
       if (reference) updateData.payout_reference = reference
       if (notes) updateData.payout_notes = notes
-      if (status === 'completed') updateData.payout_date = new Date().toISOString()
+      if (nextStatus === 'completed') updateData.payout_date = new Date().toISOString()
 
       const { data, error: updateError } = await supabaseAdmin
         .from('event_payouts')

--- a/app/api/events/[id]/register/route.ts
+++ b/app/api/events/[id]/register/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
 
+/**
+ * Public RSVP registration only.
+ * Paid tickets must go through PayPal checkout (/api/paypal/create-order + capture,
+ * or /api/events/[id]/tickets/checkout) — never confirm tickets here unpaid.
+ */
 export async function POST(req: NextRequest, { params }: any) {
   try {
     const { id } = params
@@ -8,11 +13,24 @@ export async function POST(req: NextRequest, { params }: any) {
     const body = await req.json().catch(() => ({}))
     const name = String(body?.name || '')
     const email = String(body?.email || '')
-    const quantity = Math.max(1, Number(body?.quantity || 1))
-    const type = (String(body?.type || 'rsvp') === 'ticket') ? 'ticket' : 'rsvp'
+    const quantity = Math.max(1, Math.min(20, Number(body?.quantity || 1)))
+    const requestedType = String(body?.type || 'rsvp')
+
+    if (requestedType === 'ticket') {
+      return NextResponse.json(
+        {
+          error: 'Ticket registration requires payment. Use the ticket checkout flow.',
+        },
+        { status: 400 },
+      )
+    }
 
     if (!name && !email) {
       return NextResponse.json({ error: 'Name or email required' }, { status: 400 })
+    }
+
+    if (!supabaseAdmin) {
+      return NextResponse.json({ error: 'Database unavailable' }, { status: 500 })
     }
 
     const { data: eventRow, error: evErr } = await (supabaseAdmin as any)
@@ -20,7 +38,7 @@ export async function POST(req: NextRequest, { params }: any) {
       .select('id, is_published')
       .eq('id', id)
       .single()
-    if (evErr || !eventRow) return NextResponse.json({ error: 'Event not found', details: evErr }, { status: 404 })
+    if (evErr || !eventRow) return NextResponse.json({ error: 'Event not found' }, { status: 404 })
 
     // Require published events for public RSVP
     if (eventRow && eventRow.is_published === false) {
@@ -31,7 +49,7 @@ export async function POST(req: NextRequest, { params }: any) {
       .from('event_registrations')
       .insert({
         event_id: id,
-        type,
+        type: 'rsvp',
         quantity,
         name: name || null,
         email: email || null,
@@ -40,11 +58,9 @@ export async function POST(req: NextRequest, { params }: any) {
       .select('*')
       .single()
 
-    if (error) return NextResponse.json({ error: error.message, details: error }, { status: 400 })
+    if (error) return NextResponse.json({ error: error.message }, { status: 400 })
     return NextResponse.json({ registration: data })
   } catch (e) {
     return NextResponse.json({ error: e instanceof Error ? e.message : 'Unknown error' }, { status: 500 })
   }
 }
-
-

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -2,9 +2,10 @@ import { NextRequest, NextResponse } from 'next/server'
 import { supabase, supabaseAdmin } from '@/lib/supabase'
 import { updateEventSchema } from '@/lib/validators'
 import { ok, fail } from '@/lib/api'
-import { requireAuth, requireEventAccess } from '@/lib/auth-utils'
+import { authenticateRequest, requireAuth, requireEventAccess, checkEventAccess } from '@/lib/auth-utils'
+import { resolvePlatformAdminAccess } from '@/lib/platform-admin'
 
-export async function GET(_req: Request, { params }: any) {
+export async function GET(req: NextRequest, { params }: any) {
   try {
     // Prefer admin client to avoid auth/env issues; fall back to public client
     const db = supabaseAdmin || supabase
@@ -39,6 +40,23 @@ export async function GET(_req: Request, { params }: any) {
   }
   
   if (error) return NextResponse.json({ error: error.message }, { status: 404 })
+
+  // Draft / unpublished events: owner or platform admin only (no public IDOR).
+  if (data && data.is_published === false) {
+    const auth = await authenticateRequest(req)
+    if (!auth.user || !auth.db) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+    try {
+      const { isOwner } = await checkEventAccess(auth.db, auth.user.id, id)
+      const platform = await resolvePlatformAdminAccess(auth.user)
+      if (!isOwner && !platform.isPlatformAdmin) {
+        return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+      }
+    } catch {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+  }
   
   // Process event with ticket data
   if (data && data.event_tickets && data.event_tickets.length > 0) {
@@ -48,7 +66,7 @@ export async function GET(_req: Request, { params }: any) {
     data.ticket_currency = ticket.currency
     data.ticket_quantity = ticket.quantity_total
     data.tickets_sold = ticket.quantity_sold || 0
-  } else {
+  } else if (data) {
     data.is_ticketed = false
   }
   

--- a/app/api/events/[id]/tickets/checkout/route.ts
+++ b/app/api/events/[id]/tickets/checkout/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
 import { createDonationOrder } from '@/lib/paypal'
-import { requireEventAccess } from '@/lib/auth-utils'
 
 export async function POST(req: NextRequest, { params }: any) {
   try {
@@ -91,15 +90,17 @@ export async function POST(req: NextRequest, { params }: any) {
     
     console.log('[api/tickets/checkout] Registration created:', registration.id)
 
-    // Create PayPal order for ticket purchase
+    // Create PayPal order for ticket purchase (server-priced; name/email are metadata only)
     const totalAmount = totalCents / 100
     console.log('[api/tickets/checkout] Creating PayPal order for amount:', totalAmount)
     
+    const currency = String(ticket.currency || 'USD')
     const paypalOrder = await createDonationOrder(
-      id, // eventId
-      totalAmount, // amount
-      name, // donorName
-      email // donorEmail
+      id,
+      totalAmount,
+      currency,
+      name || undefined,
+      email || undefined,
     )
 
     if (!paypalOrder?.success) {
@@ -108,6 +109,41 @@ export async function POST(req: NextRequest, { params }: any) {
     }
 
     console.log('[api/tickets/checkout] PayPal order created:', paypalOrder.orderId)
+
+    // Persist order so /tickets/process can reconcile capture → registration
+    const { error: orderInsertError } = await supabaseAdmin.from('paypal_orders').insert({
+      order_id: paypalOrder.orderId,
+      event_id: id,
+      amount_cents: totalCents,
+      platform_fee_cents: feeCents,
+      paypal_fee_cents: 0,
+      net_amount_cents: netCents,
+      status: 'pending',
+      type: 'ticket',
+      ticket_id: ticket.id,
+      quantity,
+      registration_id: registration.id,
+    })
+    if (orderInsertError) {
+      // registration_id column may be absent in older schemas — retry without it
+      const msg = (orderInsertError as { message?: string }).message ?? ''
+      if (msg.includes('registration_id')) {
+        await supabaseAdmin.from('paypal_orders').insert({
+          order_id: paypalOrder.orderId,
+          event_id: id,
+          amount_cents: totalCents,
+          platform_fee_cents: feeCents,
+          paypal_fee_cents: 0,
+          net_amount_cents: netCents,
+          status: 'pending',
+          type: 'ticket',
+          ticket_id: ticket.id,
+          quantity,
+        })
+      } else {
+        console.error('[api/tickets/checkout] Failed to store paypal order:', orderInsertError)
+      }
+    }
 
     return NextResponse.json({
       success: true,

--- a/app/api/organizer/payouts/cashout/route.ts
+++ b/app/api/organizer/payouts/cashout/route.ts
@@ -61,7 +61,8 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Event not found' }, { status: 404 })
     }
     const ownerId = eventRow.organizer_id || eventRow.created_by
-    if (ownerId && ownerId !== userId) {
+    // Deny when ownership is missing or does not match — never allow orphan bypass.
+    if (!ownerId || ownerId !== userId) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
     }
 

--- a/app/api/paypal/create-order/route.ts
+++ b/app/api/paypal/create-order/route.ts
@@ -2,27 +2,32 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createDonationOrder, calculatePlatformFee } from '@/lib/paypal'
 import { supabaseAdmin } from '@/lib/supabase'
 import { loadActivePersonalCampaign } from '@/lib/p2p/personal-campaigns'
+import { centsToDollars, dollarsToCents } from '@/lib/money/cents'
+
+/** Soft upper bound for free-form donations (USD). Tickets use DB price. */
+const MAX_DONATION_DOLLARS = 50_000
 
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json()
     const {
       eventId,
-      amount,
+      amount: clientAmount,
       type,
       ticketId,
-      quantity,
+      quantity: rawQuantity,
       currency = 'USD',
       personalCampaignId,
     } = body
     const headerIdempotencyKey = req.headers.get('idempotency-key')?.trim()
+    const quantity = Math.max(1, Math.min(100, Number(rawQuantity) || 1))
 
-    if (!eventId || !amount || !type) {
+    if (!eventId || !type) {
       return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
     }
 
-    if (amount <= 0) {
-      return NextResponse.json({ error: 'Invalid amount' }, { status: 400 })
+    if (!['donation', 'ticket'].includes(String(type))) {
+      return NextResponse.json({ error: 'Invalid type' }, { status: 400 })
     }
 
     // Verify event exists
@@ -42,6 +47,63 @@ export async function POST(req: NextRequest) {
 
     if (event.is_published === false) {
       return NextResponse.json({ error: 'Event is not published' }, { status: 400 })
+    }
+
+    // Server-authoritative amount: never trust client price for tickets.
+    let amount: number
+    let resolvedTicketId: string | null = ticketId || null
+
+    if (type === 'ticket') {
+      if (!ticketId) {
+        return NextResponse.json({ error: 'ticketId required for ticket orders' }, { status: 400 })
+      }
+      const { data: ticket, error: ticketError } = await supabaseAdmin
+        .from('event_tickets')
+        .select('id, event_id, price_cents, quantity_total, quantity_sold, sales_start_at, sales_end_at')
+        .eq('id', ticketId)
+        .eq('event_id', eventId)
+        .single()
+
+      if (ticketError || !ticket) {
+        return NextResponse.json({ error: 'Ticket not found' }, { status: 404 })
+      }
+
+      const now = Date.now()
+      if (ticket.sales_start_at && new Date(ticket.sales_start_at).getTime() > now) {
+        return NextResponse.json({ error: 'Ticket sales have not started' }, { status: 400 })
+      }
+      if (ticket.sales_end_at && new Date(ticket.sales_end_at).getTime() < now) {
+        return NextResponse.json({ error: 'Ticket sales have ended' }, { status: 400 })
+      }
+      if (
+        ticket.quantity_total != null &&
+        Number(ticket.quantity_sold || 0) + quantity > Number(ticket.quantity_total)
+      ) {
+        return NextResponse.json({ error: 'Not enough tickets available' }, { status: 400 })
+      }
+
+      const unitCents = Number(ticket.price_cents)
+      if (!Number.isFinite(unitCents) || unitCents < 0) {
+        return NextResponse.json({ error: 'Invalid ticket price' }, { status: 400 })
+      }
+      amount = centsToDollars(unitCents * quantity)
+      resolvedTicketId = ticket.id
+    } else {
+      if (clientAmount == null || Number(clientAmount) <= 0) {
+        return NextResponse.json({ error: 'Invalid amount' }, { status: 400 })
+      }
+      try {
+        const cents = dollarsToCents(Number(clientAmount))
+        if (cents > MAX_DONATION_DOLLARS * 100) {
+          return NextResponse.json(
+            { error: `Donation amount exceeds maximum of $${MAX_DONATION_DOLLARS}` },
+            { status: 400 },
+          )
+        }
+        amount = centsToDollars(cents)
+      } catch {
+        return NextResponse.json({ error: 'Invalid amount' }, { status: 400 })
+      }
     }
 
     // Attribute donation to a P2P personal campaign when present and valid
@@ -72,9 +134,9 @@ export async function POST(req: NextRequest) {
     const requestFingerprint = [
       eventId,
       String(type),
-      String(ticketId || 'none'),
+      String(resolvedTicketId || 'none'),
       String(Math.round(Number(amount) * 100)),
-      String(quantity || 1),
+      String(quantity),
       String(currency)
     ].join('_')
     const paypalRequestId = (headerIdempotencyKey || `create_${eventId}_${requestFingerprint}`).slice(0, 108)
@@ -100,8 +162,8 @@ export async function POST(req: NextRequest) {
       net_amount_cents: Math.round(fees.netAmount * 100),
       status: 'pending',
       type: type,
-      ticket_id: ticketId || null,
-      quantity: quantity || 1,
+      ticket_id: resolvedTicketId,
+      quantity,
     }
     if (attributedPersonalCampaignId) {
       paypalOrderInsert.personal_campaign_id = attributedPersonalCampaignId

--- a/docs/PLATFORM_AUDIT_2026-08-07.md
+++ b/docs/PLATFORM_AUDIT_2026-08-07.md
@@ -1,0 +1,148 @@
+# Platform Audit — EventRaise (2026-08-07)
+
+**Scope:** Full-platform security, payments, authz, RLS, and operational posture for EventRaise (Next.js 14 + Supabase + PayPal).  
+**Branch remediations:** Critical and selected High findings patched in the same change set; remaining items tracked below.  
+**Apply DB migration:** `supabase/migrations/033_security_hardening.sql` must be applied to production/staging for trigger + RLS fixes to take effect.
+
+---
+
+## Executive summary
+
+EventRaise is a fundraising platform with guest donations, ticketing, P2P campaigns, auctions (PayPal Vault), organizer cashouts, and a platform-admin console. The audit reviewed **73 API routes**, auth helpers, PayPal/Braintree stubs, Supabase migrations/RLS, and ops surfaces.
+
+**Overall risk before remediations: Critical.**  
+The highest-impact issues were privilege escalation to platform admin via `profiles.role`, client-controlled ticket pricing, unpaid confirmed tickets, and organizers self-marking payouts completed.
+
+Several Critical/High issues are **fixed in code** in this PR. Remaining High/Medium items need follow-up (durable rate limits, capture idempotency, auction registration token binding, shared admin password model).
+
+| Severity | Found | Fixed this PR | Remaining |
+|----------|------:|--------------:|----------:|
+| Critical | 5 | 5 | 0 |
+| High | 8 | 4 | 4 |
+| Medium | 9 | 2 | 7 |
+| Low / Info | 10+ | — | tracked |
+
+---
+
+## Architecture snapshot
+
+| Layer | Notes |
+|-------|--------|
+| App | Next.js App Router under `app/` — marketing, dashboard, organizer, admin console, auctions, P2P |
+| API | ~73 `route.ts` handlers; **no `middleware.ts`** (no global edge auth/CSRF) |
+| Auth | Supabase Auth (cookie + Bearer); phone OTP (Twilio Verify); platform admin roster + shared password |
+| DB | Supabase Postgres + RLS; heavy use of `supabaseAdmin` (service role) in APIs |
+| Payments | **PayPal only** (ADR-0016). Braintree/Stripe routes sunset or legacy docs |
+| Money | ADR-0011 integer cents — auctions/P2P largely compliant; donation fee math still float dollars |
+| Observability | Sentry + PostHog present; admin audit best-effort |
+
+---
+
+## Critical findings (remediated)
+
+### C1. Privilege escalation via `profiles.role` → platform admin
+- **Was:** RLS allowed users to update their own profile with no column guard; `resolvePlatformAdminAccess` and event access treated `profiles.role === 'admin'` as admin.
+- **Fix:** Removed profile-role trust from `lib/platform-admin.ts` and `lib/auth-utils.ts`. Event access now uses owner **or** `platform_admins` / owner allowlist. Migration `033` adds a trigger blocking role self-escalation.
+
+### C2. Client-controlled ticket price on `/api/paypal/create-order`
+- **Was:** Client `amount` used for `type: 'ticket'` without reading `event_tickets.price_cents`.
+- **Fix:** Ticket orders load price from DB; client amount ignored. Donations capped at $50,000 and normalized via `lib/money/cents`.
+
+### C3. Free confirmed tickets via public `/api/events/[id]/register`
+- **Was:** Unauthenticated insert with `type: 'ticket'` and `status: 'confirmed'`.
+- **Fix:** Endpoint is RSVP-only; ticket type returns 400 directing clients to paid checkout.
+
+### C4. Organizer self-completing payouts
+- **Was:** `update_payout_status` with `completed` allowed after `requireEventAccess`.
+- **Fix:** Organizers limited to `requested`; `processing` / `completed` / `failed` / `cancelled` require platform admin.
+
+### C5. Cashout ownership bypass when owner fields null
+- **Was:** `if (ownerId && ownerId !== userId)` skipped when both IDs null.
+- **Fix:** Require `ownerId` and exact match; otherwise 403.
+
+---
+
+## High findings
+
+| ID | Status | Summary |
+|----|--------|---------|
+| H1 | **Fixed** | `/api/donations/share` — added rate limit, event publish check, message length cap |
+| H2 | Open | Shared `PLATFORM_ADMIN_PASSWORD`; access/refresh tokens returned in JSON bodies |
+| H3 | Open | Phone OTP for roster phone auto-mints platform-admin session (SIM-swap risk) |
+| H4 | **Fixed** | Cashout null-owner bypass (see C5) |
+| H5 | **Fixed** | Webhook verify no longer skips on `NODE_ENV=development` alone; needs `PAYPAL_WEBHOOK_SKIP_VERIFY=true` and non-production. Documented `PAYPAL_WEBHOOK_ID` in `env.example` |
+| H6 | Open | In-memory rate limiter ineffective across serverless instances |
+| H7 | **Fixed** | Admin preflight reduced to `{ ok, ready }` (no project ref / secret flags / admin counts) |
+| H8 | Open | No Next.js middleware for global auth/bot/rate controls |
+
+---
+
+## Medium findings (selected)
+
+| ID | Status | Summary |
+|----|--------|---------|
+| M1 | **Fixed** | Unpublished event IDOR on `GET /api/events/[id]` — drafts require owner/platform admin |
+| M2 | Open | Capture endpoints unauthenticated; amount not reconciled vs PayPal capture |
+| M3 | **Fixed** | Ticket checkout called `createDonationOrder` with wrong arity (name→currency); now persists `paypal_orders` |
+| M4 | Open | CORS credentials on `/api/*` tied to `NEXT_PUBLIC_APP_URL` — misconfig risk |
+| M5 | Open | Advanced health endpoint exposes process/env fingerprinting |
+| M6 | Open | Dual write race capture-order + webhook → possible double P2P credit |
+| M7 | Open | `personal_campaigns.total_raised_cents` client-editable — **DB trigger in 033** mitigates when applied |
+| M8 | Open | Legacy `donations` / `paypal_orders` open INSERT — **RLS deny in 033** when applied |
+| M9 | Open | Auction registration accepts arbitrary vault token; quantity_sold non-atomic |
+
+---
+
+## Positive controls observed
+
+- Service role key is not `NEXT_PUBLIC_*`
+- Cron routes require `Bearer CRON_SECRET`
+- Braintree routes return 410 (ADR-0016)
+- Auction bid RPC uses row locks / increment rules / anti-snipe
+- Platform-admins table has deny-all RLS; CRUD requires super admin
+- Admin password compare uses `timingSafeEqual`
+- Donor wall omits emails / user ids
+- Debug/test/migration routes gated on production + admin
+
+---
+
+## Remediation checklist (ops)
+
+1. **Apply migration 033** on Supabase (staging then production).
+2. Set **`PAYPAL_WEBHOOK_ID`** in Vercel for all non-local environments; do **not** set `PAYPAL_WEBHOOK_SKIP_VERIFY` in production.
+3. Audit existing `profiles.role = 'admin'` rows — revoke any that are not linked via `platform_admins` / owner allowlist.
+4. Rotate `PLATFORM_ADMIN_PASSWORD` after deploy if previously exposed in logs/clients.
+5. Prefer durable rate limiting (Upstash / Redis / Vercel KV) for auth, SMS, cashout, admin login.
+
+---
+
+## Recommended follow-ups (not in this PR)
+
+1. Per-admin secrets or Twilio OTP for platform admin (retire shared password).
+2. Unique constraints + conditional updates on donation/order capture ids; verify PayPal capture amount server-side.
+3. Atomic ticket inventory (`quantity_sold` via SQL `WHERE quantity_sold + n <= quantity_total`).
+4. Add Next.js middleware for security headers consistency, bot abuse, and auth-adjacent rate limits.
+5. Migrate remaining PayPal fee math to integer cents (`lib/money`).
+6. Harden `/api/health/advanced` and stub AI/insights endpoints.
+7. Expand automated tests for authz on create-order, register, payouts, cashout.
+
+---
+
+## Surface inventory (API auth patterns)
+
+| Pattern | Examples |
+|---------|----------|
+| Platform admin | `/api/admin/*`, `/api/payouts/*` |
+| Event owner (+ platform admin) | analytics, registrations, payouts, tickets CRUD, publish |
+| Authenticated | events CRUD, P2P, auction bid/register/vault, cashout |
+| Cron Bearer | sweep-auction-lots, process-notification-deliveries |
+| Webhook signature | `/api/paypal/webhook` |
+| Public | donations create/capture, RSVP register, donor-wall, health, auth verify |
+
+---
+
+## Testing notes
+
+- Unit tests under `__tests__/lib` cover money, auction rules, P2P, notifications — run `npm test` after install.
+- No full e2e payment suite in CI against live PayPal; use sandbox rehearsal scripts (`paypal:rehearsal`).
+- After migration 033, manually verify: (1) client cannot update `profiles.role`, (2) ticket create-order ignores underpayment, (3) register rejects `type=ticket`, (4) organizer cannot set payout `completed`.

--- a/docs/internal/qa-admin-runbook-10dlc-pending.md
+++ b/docs/internal/qa-admin-runbook-10dlc-pending.md
@@ -44,14 +44,12 @@ npm run ga:status
 
 Open: `https://www.eventraisehub.com/api/admin/auth/preflight`
 
+Expect JSON like `{ "ok": true, "ready": true }` when service role, admin password, Supabase URL, and an active platform admin roster row are configured. `ready: false` means ops config is incomplete (details are intentionally not exposed publicly).
+
 **Pass when JSON shows:**
 
-- `serviceRoleConfigured`: true
-- `adminPasswordConfigured`: true
-- `projectRefMatches`: true
-- `twilioAdminMode`: false (static admin login)
-- `activePlatformAdmins`: ≥ 1
-- `rosterError`: null
+- `ok`: true
+- `ready`: true
 
 ### 2.3 Test log template
 

--- a/env.example
+++ b/env.example
@@ -13,6 +13,8 @@ SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 NEXT_PUBLIC_PAYPAL_CLIENT_ID=your_paypal_client_id
 PAYPAL_CLIENT_SECRET=your_paypal_client_secret
 PAYPAL_ENVIRONMENT=sandbox
+# Required in production for webhook signature verification (Dashboard → Webhooks)
+PAYPAL_WEBHOOK_ID=your_paypal_webhook_id
 # Client-visible flag for sandbox UI (practice vault button). Omit or set sandbox on Vercel when PAYPAL_ENVIRONMENT=sandbox.
 NEXT_PUBLIC_PAYPAL_ENVIRONMENT=sandbox
 
@@ -67,5 +69,5 @@ ALERT_WEBHOOK_URL=your_slack_or_discord_webhook_url
 # Hobby: at most one cron/day — schedule in vercel.json is daily. Pro: you may use e.g. `*/5 * * * *` for ~5 min sweeps.
 CRON_SECRET=generate_a_long_random_string
 
-# Auctions (Sprint 3) — optional: allow register without vault (dev only)
-# AUCTION_ALLOW_PENDING_REGISTRATION=true
+# Optional local-only: skip PayPal webhook signature checks (never in production)
+# PAYPAL_WEBHOOK_SKIP_VERIFY=true

--- a/lib/auth-utils.ts
+++ b/lib/auth-utils.ts
@@ -69,7 +69,9 @@ export async function authenticateRequest(req: NextRequest): Promise<AuthResult>
 }
 
 /**
- * Check if user is owner or admin of an event
+ * Check if user is owner of an event.
+ * Platform-admin bypass is applied in requireEventAccess via the roster /
+ * owner allowlist — never via profiles.role (privilege-escalation vector).
  */
 export async function checkEventAccess(db: any, userId: string, eventId: string): Promise<{ isOwner: boolean; isAdmin: boolean; event: any }> {
   const { data: ev, error: evErr } = await db
@@ -84,16 +86,7 @@ export async function checkEventAccess(db: any, userId: string, eventId: string)
   
   const isOwner = userId === (ev.organizer_id ?? ev.created_by)
   
-  // Check if user is admin
-  const { data: profile } = await db
-    .from('profiles')
-    .select('role')
-    .eq('id', userId)
-    .single()
-  
-  const isAdmin = profile?.role === 'admin'
-  
-  return { isOwner, isAdmin, event: ev }
+  return { isOwner, isAdmin: false, event: ev }
 }
 
 /**
@@ -110,14 +103,15 @@ export async function requireAuth(req: NextRequest): Promise<AuthResult> {
 }
 
 /**
- * Standardized event owner/admin check
+ * Standardized event owner / platform-admin check
  */
 export async function requireEventAccess(req: NextRequest, eventId: string): Promise<AuthResult & { event: any }> {
   const auth = await requireAuth(req)
   
-  const { isOwner, isAdmin, event } = await checkEventAccess(auth.db, auth.user.id, eventId)
+  const { isOwner, event } = await checkEventAccess(auth.db, auth.user.id, eventId)
+  const platform = await resolvePlatformAdminAccess(auth.user)
   
-  if (!isOwner && !isAdmin) {
+  if (!isOwner && !platform.isPlatformAdmin) {
     throw new Error('Forbidden')
   }
   

--- a/lib/paypal.ts
+++ b/lib/paypal.ts
@@ -215,8 +215,13 @@ export async function captureOrder(orderId: string, requestId?: string) {
 
 // Verify PayPal webhook signature
 export async function verifyWebhookSignature(headers: any, body: string): Promise<boolean> {
-  // Skip verification in development
-  if (process.env.NODE_ENV === 'development') {
+  // Explicit local-only bypass — never infer from NODE_ENV alone (staging
+  // misconfig must not accept forged webhooks).
+  if (
+    process.env.PAYPAL_WEBHOOK_SKIP_VERIFY === 'true' &&
+    process.env.NODE_ENV !== 'production'
+  ) {
+    console.warn('[paypal] webhook signature verification skipped (PAYPAL_WEBHOOK_SKIP_VERIFY)')
     return true
   }
   

--- a/lib/platform-admin.ts
+++ b/lib/platform-admin.ts
@@ -95,7 +95,11 @@ export type PlatformAdminAccess = {
   row: PlatformAdminRow | null;
 };
 
-/** Env allowlist (legacy) + platform_admins + profiles.role = admin */
+/**
+ * Env allowlist (legacy owner) + active platform_admins roster only.
+ * Do NOT trust profiles.role — that column is self-updatable via RLS unless
+ * migration 033 is applied, and must never grant platform console access.
+ */
 export async function resolvePlatformAdminAccess(user: User | null): Promise<PlatformAdminAccess> {
   if (!user) {
     return { isPlatformAdmin: false, isSuperAdmin: false, role: null, row: null };
@@ -113,17 +117,6 @@ export async function resolvePlatformAdminAccess(user: User | null): Promise<Pla
       role: row.role,
       row,
     };
-  }
-
-  if (supabaseAdmin) {
-    const { data: profile } = await supabaseAdmin
-      .from("profiles")
-      .select("role")
-      .eq("id", user.id)
-      .maybeSingle();
-    if (profile?.role === "admin") {
-      return { isPlatformAdmin: true, isSuperAdmin: false, role: "admin", row: null };
-    }
   }
 
   return { isPlatformAdmin: false, isSuperAdmin: false, role: null, row: null };

--- a/supabase/migrations/033_security_hardening.sql
+++ b/supabase/migrations/033_security_hardening.sql
@@ -1,0 +1,99 @@
+-- Migration 033: Security hardening from platform audit (2026-08-07)
+-- Blocks profile role self-escalation, protects P2P raised totals,
+-- and tightens overly permissive INSERT policies on finance tables.
+
+-- ---------------------------------------------------------------------------
+-- 1) Prevent authenticated users from changing profiles.role
+--    Service role (API / ensureProfileAdminRole) bypasses RLS and still can
+--    update; this trigger rejects role changes under the authenticated JWT.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.prevent_profile_role_self_escalation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF TG_OP = 'UPDATE' AND NEW.role IS DISTINCT FROM OLD.role THEN
+    IF coalesce(auth.role(), '') IS DISTINCT FROM 'service_role' THEN
+      RAISE EXCEPTION 'Changing profile role is not allowed'
+        USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  IF TG_OP = 'INSERT' AND NEW.role IS NOT NULL AND NEW.role IS DISTINCT FROM 'user' THEN
+    IF coalesce(auth.role(), '') IS DISTINCT FROM 'service_role' THEN
+      NEW.role := 'user';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_prevent_profile_role_self_escalation ON public.profiles;
+CREATE TRIGGER trg_prevent_profile_role_self_escalation
+  BEFORE INSERT OR UPDATE ON public.profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.prevent_profile_role_self_escalation();
+
+-- ---------------------------------------------------------------------------
+-- 2) Protect personal_campaigns.total_raised_cents from client edits
+--    Rollups must come from donation triggers / service role only.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.protect_personal_campaign_totals()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF TG_OP = 'UPDATE'
+     AND NEW.total_raised_cents IS DISTINCT FROM OLD.total_raised_cents THEN
+    IF coalesce(auth.role(), '') IS DISTINCT FROM 'service_role' THEN
+      NEW.total_raised_cents := OLD.total_raised_cents;
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_personal_campaign_totals ON public.personal_campaigns;
+CREATE TRIGGER trg_protect_personal_campaign_totals
+  BEFORE UPDATE ON public.personal_campaigns
+  FOR EACH ROW
+  EXECUTE FUNCTION public.protect_personal_campaign_totals();
+
+-- ---------------------------------------------------------------------------
+-- 3) Tighten paypal_orders INSERT — service role only (APIs use admin client)
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS "Public can create PayPal orders" ON public.paypal_orders;
+DROP POLICY IF EXISTS paypal_orders_insert_service ON public.paypal_orders;
+CREATE POLICY paypal_orders_insert_deny_clients ON public.paypal_orders
+  FOR INSERT
+  WITH CHECK (false);
+
+-- ---------------------------------------------------------------------------
+-- 4) Tighten legacy donations open write policies
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS "Anyone can create donations" ON public.donations;
+DROP POLICY IF EXISTS "Anyone can update donations" ON public.donations;
+DROP POLICY IF EXISTS donations_insert_deny_clients ON public.donations;
+DROP POLICY IF EXISTS donations_update_deny_clients ON public.donations;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'donations'
+  ) THEN
+    EXECUTE $p$
+      CREATE POLICY donations_insert_deny_clients ON public.donations
+        FOR INSERT WITH CHECK (false)
+    $p$;
+    EXECUTE $p$
+      CREATE POLICY donations_update_deny_clients ON public.donations
+        FOR UPDATE USING (false)
+    $p$;
+  END IF;
+END $$;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Full-platform security audit of EventRaise (APIs, authz, PayPal money paths, RLS, admin console). Findings documented in `docs/PLATFORM_AUDIT_2026-08-07.md`.

### Critical fixes included
- Stop trusting `profiles.role` for platform/event admin (use `platform_admins` + owner allowlist)
- Migration `033_security_hardening.sql`: block role self-escalation; protect P2P raised totals; deny client inserts on `paypal_orders` / legacy `donations`
- Server-side ticket pricing on `/api/paypal/create-order` (ignore client amount for tickets)
- Public register is RSVP-only (no unpaid confirmed tickets)
- Organizers cannot mark payouts `completed` (platform admin only)
- Cashout denies when event owner fields are null
- SMS share rate-limited + event publish check
- Admin preflight reduced to `{ ok, ready }`
- PayPal webhook verify no longer skips on `NODE_ENV=development` alone
- Ticket checkout PayPal arity bug fixed + `paypal_orders` persistence
- Unpublished event GET requires owner/platform admin

### Ops required after merge
1. Apply migration `033` on Supabase
2. Set `PAYPAL_WEBHOOK_ID` in Vercel
3. Audit existing `profiles.role = 'admin'` rows

### Remaining (documented, not fixed here)
Shared admin password, durable rate limits, capture amount reconciliation / double-credit races, Next.js middleware.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7929e95c-62cb-4f06-a5bf-6d16deb3bcfe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7929e95c-62cb-4f06-a5bf-6d16deb3bcfe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

